### PR TITLE
Publish new node-pm2:20.14.0 docker image

### DIFF
--- a/.github/workflows/node-pm2.yaml
+++ b/.github/workflows/node-pm2.yaml
@@ -8,7 +8,7 @@ jobs:
 
     env:
       DOCKER_IMAGE_NAME: samarpanda/node-pm2
-      DOCKER_IMAGE_TAG: 0.0.1
+      DOCKER_IMAGE_TAG: 20.14.0
 
     steps:
       - name: Checkout code

--- a/node-pm2/Dockerfile
+++ b/node-pm2/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:18-alpine
+FROM node:20.14.0-alpine
 
-ENV NODE_PM2_VERSION=0.0.1
-ENV NODE_VERSION=18.19.0
-ENV NPM_VERSION=10.2.3
-ENV PM2_VERSION=5.3.0
+ENV NODE_PM2_VERSION=20.14.0
+ENV NODE_VERSION=20.14.0
+ENV NPM_VERSION=10.7.0
+ENV PM2_VERSION=5.4.0
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash curl
 WORKDIR /node
 ENV NPM_CONFIG_PREFIX=/node/.npm-global
 ENV PATH=$PATH:/node/.npm-global/bin
-RUN npm install pm2@5.3.0 -g --only=production
+RUN npm install pm2@5.4.0 -g --only=production
 
 #WORKDIR /app
 #RUN echo "registry=https://registry.npmjs.org" > .npmrc


### PR DESCRIPTION
# Publish new node-pm2:20.14.0 docker image

1. Node(v20.14.0) 
2. PM2(v5.4.0) 

Dockerhub [samarpanda/node-pm2:20.14.0](https://hub.docker.com/repository/docker/samarpanda/node-pm2/tags?page=&page_size=&ordering=&name=20.14.0)



